### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
         None => println!("Invalid day, or I've not written a solution for that one yet!"),
         Some(solve) => {
             let (p1,p2) = solve(input);
-            println!("Solved in {:.}ms", (curr.elapsed().as_nanos() as f64 )/1000000.0);
+            println!("Solved in {}ms", (curr.elapsed().as_nanos() as f64 )/1000000.0);
             println!("Part 1: {}\nPart 2: {}", p1, p2)
         }
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.